### PR TITLE
Replace string literals for notifications with static vars

### DIFF
--- a/Volumio.xcodeproj/project.pbxproj
+++ b/Volumio.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		09EBB60B1E254CD90081654E /* SocketIOManagerNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09EBB60A1E254CD90081654E /* SocketIOManagerNotifications.swift */; };
 		6005E4EB1D9916A5000B80AE /* TrackObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6005E4EA1D9916A5000B80AE /* TrackObject.swift */; };
 		601424771D916F0C001159B2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 601424761D916F0C001159B2 /* Assets.xcassets */; };
 		601424791D9173A3001159B2 /* PlaybackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 601424781D9173A3001159B2 /* PlaybackViewController.swift */; };
@@ -64,6 +65,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		09EBB60A1E254CD90081654E /* SocketIOManagerNotifications.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SocketIOManagerNotifications.swift; sourceTree = "<group>"; };
 		17DCEBEF3691DD5604EFC3CD /* Pods_Volumio.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Volumio.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2C8907F5DE990FDB9081F117 /* Pods-Volumio.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Volumio.release.xcconfig"; path = "Pods/Target Support Files/Pods-Volumio/Pods-Volumio.release.xcconfig"; sourceTree = "<group>"; };
 		6005E4EA1D9916A5000B80AE /* TrackObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrackObject.swift; sourceTree = "<group>"; };
@@ -159,6 +161,7 @@
 			children = (
 				60BC9ED71D9D148D00AEBBFF /* LastFmManager.swift */,
 				60B2261F1DCA887F00B74B57 /* SocketIOManager.swift */,
+				09EBB60A1E254CD90081654E /* SocketIOManagerNotifications.swift */,
 			);
 			name = Manager;
 			sourceTree = "<group>";
@@ -455,6 +458,7 @@
 				60AE8C7F1DBA4F0900B1E0C8 /* NetworkObject.swift in Sources */,
 				60EC70511DC22A59009D0F61 /* SwipeLeft.swift in Sources */,
 				6074D2751DBB9273000F2285 /* SearchResultObject.swift in Sources */,
+				09EBB60B1E254CD90081654E /* SocketIOManagerNotifications.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Volumio/BrowseFolderTableViewController.swift
+++ b/Volumio/BrowseFolderTableViewController.swift
@@ -69,17 +69,17 @@ class BrowseFolderTableViewController: UITableViewController, BrowseActionsDeleg
     }
     
     private func registerObservers() {
-        NotificationCenter.default.addObserver(self, selector: #selector(updateSourceLibrary(notification:)), name: NSNotification.Name("browseLibrary"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(updateSourceLibrary(notification:)), name: .browseLibrary, object: nil)
         
-        NotificationCenter.default.addObserver(self, selector: #selector(deletePlaylist(notification:)), name: NSNotification.Name("playlistDeleted"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(deletePlaylist(notification:)), name: .playlistDeleted, object: nil)
         
-        NotificationCenter.default.addObserver(self, selector: #selector(addToQueue(notification:)), name: NSNotification.Name("addedToQueue"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(addToQueue(notification:)), name: .addedToQueue, object: nil)
         
-        NotificationCenter.default.addObserver(self, selector: #selector(addToPlaylist(notification:)), name: NSNotification.Name("addedToPlaylist"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(addToPlaylist(notification:)), name: .addedToPlaylist, object: nil)
         
-        NotificationCenter.default.addObserver(self, selector: #selector(removeFromPlaylist(notification:)), name: NSNotification.Name("removedFromPlaylist"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(removeFromPlaylist(notification:)), name: .removedFromPlaylist, object: nil)
         
-        NotificationCenter.default.addObserver(self, selector: #selector(playPlaylist(notification:)), name: NSNotification.Name("playlistPlaying"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(playPlaylist(notification:)), name: .playlistPlaying, object: nil)
     }
     
     func updateSourceLibrary(notification: NSNotification) {

--- a/Volumio/BrowseFolderTableViewController.swift
+++ b/Volumio/BrowseFolderTableViewController.swift
@@ -22,15 +22,15 @@ class BrowseFolderTableViewController: UITableViewController, BrowseActionsDeleg
     var sourceLibrarySections = [LibraryObject]()
     var sourceLibraryDict = [String: [String]]()
     
-    func generateLibraryDict() {
-        for source in sourceLibrary {
-            let key = "\(source[(source.title?.startIndex)!])"
-            if var sourceValues = sourceLibraryDict[key] {
-                sourceValue
-            }
-        }
-    }
-    
+//    func generateLibraryDict() {
+//        for source in sourceLibrary {
+//            let key = "\(source[(source.title?.startIndex)!])"
+//            if var sourceValues = sourceLibraryDict[key] {
+//                sourceValue
+//            }
+//        }
+//    }
+	
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         SocketIOManager.sharedInstance.browseLibrary(uri: serviceUri)

--- a/Volumio/BrowseSearchTableViewController.swift
+++ b/Volumio/BrowseSearchTableViewController.swift
@@ -41,9 +41,9 @@ class BrowseSearchTableViewController: UITableViewController, UISearchBarDelegat
     }
     
     private func registerObservers() {
-        NotificationCenter.default.addObserver(self, selector: #selector(updateSources(notification:)), name: NSNotification.Name("browseSearch"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(updateSources(notification:)), name: .browseSearch, object: nil)
         
-        NotificationCenter.default.addObserver(self, selector: #selector(isOnPlaylist(notification:)), name: NSNotification.Name("addedToPlaylist"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(isOnPlaylist(notification:)), name: .addedToPlaylist, object: nil)
     }
 
     func updateSources(notification: NSNotification) {

--- a/Volumio/BrowseSourcesTableViewController.swift
+++ b/Volumio/BrowseSourcesTableViewController.swift
@@ -39,7 +39,7 @@ class BrowseSourcesTableViewController: UITableViewController {
     }
     
     private func registerObservers() {
-        NotificationCenter.default.addObserver(self, selector: #selector(updateSources(notification:)), name: NSNotification.Name("browseSources"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(updateSources(notification:)), name: .browseSources, object: nil)
     }
     
     func updateSources(notification: NSNotification) {

--- a/Volumio/NetworksTableViewController.swift
+++ b/Volumio/NetworksTableViewController.swift
@@ -41,9 +41,9 @@ class NetworksTableViewController: UITableViewController {
     }
     
     private func registerObservers() {
-        NotificationCenter.default.addObserver(self, selector: #selector(getNetworks(notification:)), name: NSNotification.Name("browseNetwork"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(getNetworks(notification:)), name: .browseNetwork, object: nil)
         
-        NotificationCenter.default.addObserver(self, selector: #selector(getWireless(notification:)), name: NSNotification.Name("browseWifi"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(getWireless(notification:)), name: .browseWifi, object: nil)
     }
     
     func getNetworks(notification: NSNotification) {

--- a/Volumio/PlaybackViewController.swift
+++ b/Volumio/PlaybackViewController.swift
@@ -91,11 +91,11 @@ class PlaybackViewController: UIViewController {
         
         NotificationCenter.default.addObserver(self, selector: #selector(getCurrentTrackInfo), name: NSNotification.Name.UIApplicationWillEnterForeground, object: nil)
         
-        NotificationCenter.default.addObserver(self, selector: #selector(isDisconnected(notification:)), name: NSNotification.Name("disconnected"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(isDisconnected(notification:)), name: .disconnected, object: nil)
         
-        NotificationCenter.default.addObserver(self, selector: #selector(getCurrentTrack(notification:)), name: NSNotification.Name("currentTrack"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(getCurrentTrack(notification:)), name: .currentTrack, object: nil)
         
-        NotificationCenter.default.addObserver(self, selector: #selector(isOnPlaylist(notification:)), name: NSNotification.Name("addedToPlaylist"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(isOnPlaylist(notification:)), name: .addedToPlaylist, object: nil)
     }
     
     func isDisconnected(notification: NSNotification) {

--- a/Volumio/PlaylistAddViewController.swift
+++ b/Volumio/PlaylistAddViewController.swift
@@ -44,7 +44,7 @@ class PlaylistAddViewController: UIViewController, UITableViewDelegate, UITableV
     }
     
     private func registerObservers() {
-        NotificationCenter.default.addObserver(self, selector: #selector(getPlaylist(notification:)), name: NSNotification.Name("listPlaylists"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(getPlaylist(notification:)), name: .listPlaylists, object: nil)
     }
     
     func getPlaylist(notification: NSNotification) {

--- a/Volumio/PluginsTableViewController.swift
+++ b/Volumio/PluginsTableViewController.swift
@@ -40,7 +40,7 @@ class PluginsTableViewController: UITableViewController {
     }
     
     private func registerObservers() {
-        NotificationCenter.default.addObserver(self, selector: #selector(updateSources(notification:)), name: NSNotification.Name("browsePlugins"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(updateSources(notification:)), name: .browsePlugins, object: nil)
     }
     
     func updateSources(notification: NSNotification) {

--- a/Volumio/QueueTableViewController.swift
+++ b/Volumio/QueueTableViewController.swift
@@ -20,8 +20,8 @@ class QueueTableViewController: UITableViewController, QueueActionsDelegate {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        SocketIOManager.sharedInstance.getState()
         registerObservers()
+        SocketIOManager.sharedInstance.getState()
     }
 
     override func viewDidLoad() {
@@ -51,11 +51,11 @@ class QueueTableViewController: UITableViewController, QueueActionsDelegate {
 
     private func registerObservers() {
         
-        NotificationCenter.default.addObserver(self, selector: #selector(getQueue(notification:)), name: NSNotification.Name("currentQueue"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(getQueue(notification:)), name: .currentQueue, object: nil)
         
-        NotificationCenter.default.addObserver(self, selector: #selector(getCurrentTrack(notification:)), name: NSNotification.Name("currentTrack"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(getCurrentTrack(notification:)), name: .currentTrack, object: nil)
         
-        NotificationCenter.default.addObserver(self, selector: #selector(removeFromQueue(notification:)), name: NSNotification.Name("removedfromQueue"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(removeFromQueue(notification:)), name: .removedfromQueue, object: nil)
     }
     
     func getQueue(notification:NSNotification) {

--- a/Volumio/SocketIOManager.swift
+++ b/Volumio/SocketIOManager.swift
@@ -52,13 +52,13 @@ class SocketIOManager: NSObject {
             self.socketConnected = true
             self.getState()
         }
-		
-		socket.on("pushState") {data, ack in
-			if let json = data[0] as? [String : Any] {
-				self.currentTrack = Mapper<TrackObject>().map(JSONObject: json)
-				NotificationCenter.default.post(name: NSNotification.Name("currentTrack"), object: self.currentTrack)
-			}
-		}
+
+        socket.on("pushState") {data, ack in
+            if let json = data[0] as? [String : Any] {
+                self.currentTrack = Mapper<TrackObject>().map(JSONObject: json)
+                NotificationCenter.default.post(name: .currentTrack, object: self.currentTrack)
+            }
+        }
     }
 	
     func reConnect() {

--- a/Volumio/SocketIOManager.swift
+++ b/Volumio/SocketIOManager.swift
@@ -33,7 +33,7 @@ class SocketIOManager: NSObject {
     
     var socketConnected : Bool = false
     
-    // manage connection
+    // MARK: - manage connection
     
     func establishConnection() {
         
@@ -77,8 +77,7 @@ class SocketIOManager: NSObject {
         socket.disconnect()
     }
     
-    
-    //common
+    // MARK: - emit events
     
     func doAction(action:String) {
         socket.emit(action)
@@ -88,8 +87,7 @@ class SocketIOManager: NSObject {
         socket.emit("callMethod", ["endpoint": endpoint, "method": method, "data": data])
     }
     
-    
-    //manage playback
+    // MARK: - manage playback
     
     func playTrack(position:Int) {
         socket.emit("play", ["value": position])
@@ -104,8 +102,7 @@ class SocketIOManager: NSObject {
         self.socket.emit("getState")
     }
     
-    
-    //manage sources
+    // MARK: - manage sources
     
     func browseSources() {
         socket.emit("getBrowseSources")
@@ -175,7 +172,7 @@ class SocketIOManager: NSObject {
     }
     
     
-    //manage queue
+    // MARK: - manage queue
     
     func getQueue() {
         socket.emit("getQueue")
@@ -219,8 +216,7 @@ class SocketIOManager: NSObject {
         }
     }
     
-    
-    //manage playlists
+    // MARK: - manage playlists
     
     func listPlaylist() {
         self.socket.emit("listPlaylist")
@@ -268,7 +264,7 @@ class SocketIOManager: NSObject {
         }
     }
     
-    //manage plugins
+    // MARK: - manage plugins
     
     func getInstalledPlugins() {
         self.socket.emit("getInstalledPlugins")
@@ -285,7 +281,7 @@ class SocketIOManager: NSObject {
         self.socket.emit("pluginManager", ["name": name, "category": category, "action": action])
     }
     
-    //manage network
+    // MARK: - manage network
     
     func getInfoNetwork() {
         socket.emit("getInfoNetwork")
@@ -308,36 +304,10 @@ class SocketIOManager: NSObject {
             }
         }
     }
-    
-    
-    //debug
-//    socket.onAny {
-//      print("Got event: \($0.event), with items: \($0.items)")
-//    }
-    
+
 }
 
-// Notifications posted by this module
-
-extension Notification.Name {
-    static let connected = Notification.Name("connected")
-    static let disconnected = Notification.Name("disconnected")
-    static let currentTrack = Notification.Name("currentTrack")
-    static let browseSources = Notification.Name("browseSources")
-    static let browseLibrary = Notification.Name("browseLibrary")
-    static let browseSearch = Notification.Name("browseSearch")
-    static let currentQueue = Notification.Name("currentQueue")
-    static let addedToQueue = Notification.Name("addedToQueue")
-    static let removedfromQueue = Notification.Name("removedfromQueue")
-    static let listPlaylists = Notification.Name("listPlaylists")
-    static let addedToPlaylist = Notification.Name("addedToPlaylist")
-    static let removedFromPlaylist = Notification.Name("removedFromPlaylist")
-    static let playlistPlaying = Notification.Name("playlistPlaying")
-    static let playlistDeleted = Notification.Name("playlistDeleted")
-    static let browsePlugins = Notification.Name("browsePlugins")
-    static let browseNetwork = Notification.Name("browseNetwork")
-    static let browseWifi = Notification.Name("browseWifi")
-}
+// MARK: -
 
 // Convenience extension to avoid code duplication
 

--- a/Volumio/SocketIOManagerNotifications.swift
+++ b/Volumio/SocketIOManagerNotifications.swift
@@ -1,0 +1,31 @@
+//
+//  SocketIOManagerNotifications.swift
+//  Volumio
+//
+//  Created by Michael Baumgärtner on 10.01.17.
+//  Copyright © 2017 Federico Sintucci. All rights reserved.
+//
+
+import Foundation
+
+// Notifications posted by SocketIOManager
+
+extension Notification.Name {
+    static let connected = Notification.Name("connected")
+    static let disconnected = Notification.Name("disconnected")
+    static let currentTrack = Notification.Name("currentTrack")
+    static let browseSources = Notification.Name("browseSources")
+    static let browseLibrary = Notification.Name("browseLibrary")
+    static let browseSearch = Notification.Name("browseSearch")
+    static let currentQueue = Notification.Name("currentQueue")
+    static let addedToQueue = Notification.Name("addedToQueue")
+    static let removedfromQueue = Notification.Name("removedfromQueue")
+    static let listPlaylists = Notification.Name("listPlaylists")
+    static let addedToPlaylist = Notification.Name("addedToPlaylist")
+    static let removedFromPlaylist = Notification.Name("removedFromPlaylist")
+    static let playlistPlaying = Notification.Name("playlistPlaying")
+    static let playlistDeleted = Notification.Name("playlistDeleted")
+    static let browsePlugins = Notification.Name("browsePlugins")
+    static let browseNetwork = Notification.Name("browseNetwork")
+    static let browseWifi = Notification.Name("browseWifi")
+}


### PR DESCRIPTION
This is a refactoring which replaces string literals used for notification names with static vars extending Notification.Name. Additionally a small refactoring avoids code duplication when building the server’s socket url.
