### PR TITLE
Add type for Volumio’s items

### DIFF
--- a/Volumio.xcodeproj/project.pbxproj
+++ b/Volumio.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		097522DF1E38AC9F00A94A7A /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 097522DC1E38AC9F00A94A7A /* Debug.xcconfig */; };
 		097522E01E38AC9F00A94A7A /* Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 097522DD1E38AC9F00A94A7A /* Release.xcconfig */; };
 		097522E31E38CEA100A94A7A /* LastFMService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097522E21E38CEA100A94A7A /* LastFMService.swift */; };
+		097522E61E38D8DE00A94A7A /* Item.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097522E51E38D8DE00A94A7A /* Item.swift */; };
+		097522E81E38D8E800A94A7A /* Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = 097522E71E38D8E800A94A7A /* Service.swift */; };
 		09EBB6061E24FF180081654E /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 09EBB6081E24FF180081654E /* Localizable.strings */; };
 		09EBB6131E266D210081654E /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 09EBB6121E266D210081654E /* LaunchScreen.storyboard */; };
 		4C2017491E26E3E7000A2192 /* VolumioIOEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C2017481E26E3E7000A2192 /* VolumioIOEvents.swift */; };
@@ -82,6 +84,8 @@
 		097522DC1E38AC9F00A94A7A /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = VolumioConfigs/Debug.xcconfig; sourceTree = "<group>"; };
 		097522DD1E38AC9F00A94A7A /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = VolumioConfigs/Release.xcconfig; sourceTree = "<group>"; };
 		097522E21E38CEA100A94A7A /* LastFMService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LastFMService.swift; sourceTree = "<group>"; };
+		097522E51E38D8DE00A94A7A /* Item.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Item.swift; sourceTree = "<group>"; };
+		097522E71E38D8E800A94A7A /* Service.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Service.swift; sourceTree = "<group>"; };
 		09EBB6071E24FF180081654E /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
 		09EBB6091E24FF250081654E /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/Localizable.strings; sourceTree = "<group>"; };
 		09EBB6121E266D210081654E /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
@@ -180,7 +184,9 @@
 			isa = PBXGroup;
 			children = (
 				0961213E1E3121140073D7C8 /* VolumioIO */,
+				097522E51E38D8DE00A94A7A /* Item.swift */,
 				0961213C1E3120B70073D7C8 /* Player.swift */,
+				097522E71E38D8E800A94A7A /* Service.swift */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -501,6 +507,7 @@
 				6086E2AB1D9133A50067A8B5 /* AppDelegate.swift in Sources */,
 				097522D71E38AA2600A94A7A /* BundleInfo.swift in Sources */,
 				097522D01E38A9D100A94A7A /* Logging.swift in Sources */,
+				097522E61E38D8DE00A94A7A /* Item.swift in Sources */,
 				603FF51C1DAE3AD2007E1C50 /* PluginsTableViewController.swift in Sources */,
 				097522E31E38CEA100A94A7A /* LastFMService.swift in Sources */,
 				606D92451DB677BD00DBD78A /* SelectPlayerTableViewCell.swift in Sources */,
@@ -526,6 +533,7 @@
 				607ADC701DBF42680090F038 /* QueueTableViewCell.swift in Sources */,
 				4C20174B1E29A6C3000A2192 /* VolumioIOManagerNotifications.swift in Sources */,
 				606D923F1DB4D4FD00DBD78A /* Extensions.swift in Sources */,
+				097522E81E38D8E800A94A7A /* Service.swift in Sources */,
 				60E1D5D91DD0D10D00DAED54 /* PlaylistAddViewController.swift in Sources */,
 				60E781991DABCC9800C48A43 /* LibraryObject.swift in Sources */,
 				608275711DD2058E004E4E6A /* AddToPlaylistTableViewCell.swift in Sources */,

--- a/Volumio/BrowseFolderTableViewController.swift
+++ b/Volumio/BrowseFolderTableViewController.swift
@@ -192,10 +192,8 @@ class BrowseFolderTableViewController: UITableViewController,
             let cell = tableView.dequeueReusableCell(withIdentifier: "track", for: indexPath) as! TrackTableViewCell
             let track = sourceLibrary[indexPath.row]
             
-            cell.trackTitle.text = track.title ?? ""
-            let artist = track.artist ?? ""
-            let album = track.album ?? ""
-            cell.trackArtist.text = "\(artist) - \(album)"
+            cell.trackTitle.text = track.localizedTitle
+            cell.trackArtist.text = track.localizedArtistAndAlbum
             
             cell.trackImage.image = nil // TODO: quickfix for cell reuse
             

--- a/Volumio/BrowseSearchTableViewController.swift
+++ b/Volumio/BrowseSearchTableViewController.swift
@@ -48,7 +48,6 @@ class BrowseSearchTableViewController: UITableViewController, UISearchBarDelegat
             name: .browseSearch,
             object: nil
         )
-        // FIXME: dead code?
         NotificationCenter.default.addObserver(self,
             selector: #selector(isOnPlaylist(notification:)),
             name: .addedToPlaylist,
@@ -99,7 +98,7 @@ class BrowseSearchTableViewController: UITableViewController, UISearchBarDelegat
         let itemList = sourcesList[indexPath.section]
         let item = itemList.items![indexPath.row] as LibraryObject
         
-        if item.type == "song" {
+        if item.type == .song {
             let cell = tableView.dequeueReusableCell(withIdentifier: "track", for: indexPath) as! TrackTableViewCell
             
             cell.trackTitle.text = item.title ?? ""
@@ -128,7 +127,7 @@ class BrowseSearchTableViewController: UITableViewController, UISearchBarDelegat
             
             return cell
             
-        } else if item.type == "webradio" || item.type == "mywebradio" {
+        } else if item.type.isRadio {
             let cell = tableView.dequeueReusableCell(withIdentifier: "radio", for: indexPath) as! FolderTableViewCell
             
             cell.folderTitle.text = item.title ?? ""
@@ -262,16 +261,27 @@ class BrowseSearchTableViewController: UITableViewController, UISearchBarDelegat
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if segue.identifier == "browseFolder" {
-            guard let indexPath = self.tableView.indexPathForSelectedRow else { return }
+            guard let indexPath = tableView.indexPathForSelectedRow else { return }
                 
             let itemList = sourcesList[indexPath.section]
-            let item = itemList.items![indexPath.row] as LibraryObject
+            let items = itemList.items
+            if let items = items {
+                let item = items[indexPath.row] as LibraryObject
             
-            let destinationController = segue.destination as! BrowseFolderTableViewController
-            destinationController.serviceName = item.title
-            destinationController.serviceUri = item.uri
-            destinationController.serviceType = item.type
-            destinationController.serviceService = item.service
+                let destinationController = segue.destination as! BrowseFolderTableViewController
+
+                switch item.type {
+                case .folder:
+                    destinationController.serviceType = .folder
+                case .playlist:
+                    destinationController.serviceType = .playlist
+                default:
+                    destinationController.serviceType = .generic
+                }
+                destinationController.serviceName = item.title
+                destinationController.serviceUri = item.uri
+                destinationController.serviceService = item.service
+            }
         }
     }
 }

--- a/Volumio/BrowseSearchTableViewController.swift
+++ b/Volumio/BrowseSearchTableViewController.swift
@@ -101,10 +101,8 @@ class BrowseSearchTableViewController: UITableViewController, UISearchBarDelegat
         if item.type == .song {
             let cell = tableView.dequeueReusableCell(withIdentifier: "track", for: indexPath) as! TrackTableViewCell
             
-            cell.trackTitle.text = item.title ?? ""
-            let artist = item.artist ?? ""
-            let album = item.album ?? ""
-            cell.trackArtist.text = "\(artist) - \(album)"
+            cell.trackTitle.text = item.localizedTitle
+            cell.trackArtist.text = item.localizedArtistAndAlbum
             
             cell.trackImage.image = nil // TODO: quickfix for cell reuse
 

--- a/Volumio/BrowseSourcesTableViewController.swift
+++ b/Volumio/BrowseSourcesTableViewController.swift
@@ -90,10 +90,18 @@ class BrowseSourcesTableViewController: UITableViewController {
         if segue.identifier == "showFolder" {
             guard let indexPath = self.tableView.indexPathForSelectedRow else { return }
             
+            let item = sourcesList[indexPath.row]
+            
             let destinationController = segue.destination as! BrowseFolderTableViewController
-            destinationController.serviceName = sourcesList[indexPath.row].name
-            destinationController.serviceUri = sourcesList[indexPath.row].uri
-            destinationController.serviceType = sourcesList[indexPath.row].plugin_type
+
+            switch item.plugin_type {
+            case .some("music_service"):
+                destinationController.serviceType = .music_service
+            default:
+                destinationController.serviceType = .generic
+            }
+            destinationController.serviceName = item.name
+            destinationController.serviceUri = item.uri
         }
     }
 

--- a/Volumio/Extensions.swift
+++ b/Volumio/Extensions.swift
@@ -11,6 +11,16 @@ import UIKit
 class Extensions: NSObject {
 }
 
+// MARK: - Swift
+
+extension String {
+    
+    /// Returns true if the specified string contains only whitespace characters or is empty.
+    var isBlank: Bool {
+        return trimmingCharacters(in: CharacterSet.whitespacesAndNewlines).isEmpty
+    }
+}
+
 // MARK: - Foundation
 
 extension Collection where Indices.Iterator.Element == Index {

--- a/Volumio/Item.swift
+++ b/Volumio/Item.swift
@@ -1,0 +1,32 @@
+//
+//  Item
+//  Volumio
+//
+//  Created by Michael Baumgärtner on 23.01.17.
+//  Copyright © 2017 Federico Sintucci. All rights reserved.
+//
+
+import Foundation
+
+enum ItemType: String {
+    case title
+    case track
+    case folder
+    case playlist
+    case song
+    case cuesong
+    case webradio
+    case mywebradio
+    case radio_favourites = "radio-favourites"
+    case radio_category = "radio-category"
+    case unknown
+    
+    var isSong: Bool {
+        return self == .song || self == .cuesong
+    }
+
+    var isRadio: Bool {
+        return self == .webradio || self == .mywebradio
+    }
+
+}

--- a/Volumio/Item.swift
+++ b/Volumio/Item.swift
@@ -1,5 +1,5 @@
 //
-//  Item
+//  Item.swift
 //  Volumio
 //
 //  Created by Michael Baumgärtner on 23.01.17.
@@ -7,6 +7,26 @@
 //
 
 import Foundation
+
+/**
+ This represents a Volumio item. It can be a song, a playlist, a folder, and so forth.
+*/
+protocol Item {
+    /// Type of this Volumio item (track, song, playlist, folder, ...)
+    var type: ItemType { get }
+    
+    /// Title for this item.
+    var title: String? { get }
+    /// Name for this item. Tracks have names, for all other items this is nil.
+    var name: String? { get }
+
+    /// Artist for this item. Maybe nil for some types.
+    var artist: String? { get }
+    /// Album for this item. Maybe nil for some types.
+    var album: String? { get }
+    /// Album art url string for this item. Maybe nil for some types.
+    var albumArt: String? { get }
+}
 
 enum ItemType: String {
     case title
@@ -27,6 +47,44 @@ enum ItemType: String {
 
     var isRadio: Bool {
         return self == .webradio || self == .mywebradio
+    }
+
+}
+
+// MARK: - Localization
+
+// Localized strings for this item. Note: Some of this methods don’t really localize anything, but return a resonable default string if data is missing.
+
+extension Item {
+    
+    /// Returns the title of this item or an empty string if title data is missing.
+    var localizedTitle: String {
+        return title ?? name ?? ""
+    }
+
+    /// Returns the artist for this item or an empty string if artist data is missing.
+    var localizedArtist: String {
+        return artist ?? ""
+    }
+    
+    /// Returns the album of this item or an empty string if album data is missing.
+    var localizedAlbum: String {
+        return album ?? ""
+    }
+    
+    /// Returns a combined string with artist and album information for this item.
+    var localizedArtistAndAlbum: String {
+        if let artist = artist, !artist.isBlank {
+            if let album = album, !album.isBlank {
+                return "\(artist) - \(album)"
+            }
+            else {
+                return "\(artist) - No album"
+            }
+        }
+        else {
+            return album ?? ""
+        }
     }
 
 }

--- a/Volumio/LibraryObject.swift
+++ b/Volumio/LibraryObject.swift
@@ -8,13 +8,15 @@
 
 import ObjectMapper
 
-class LibraryObject: Mappable {
+class LibraryObject: Mappable, Item {
     var type: ItemType = .unknown
     
     var title: String?
+    var name: String?
     var artist: String?
     var album: String?
     var albumArt: String?
+    
     var uri: String?
     var service: String?
     

--- a/Volumio/LibraryObject.swift
+++ b/Volumio/LibraryObject.swift
@@ -9,26 +9,50 @@
 import ObjectMapper
 
 class LibraryObject: Mappable {
+    var type: ItemType = .unknown
+    
     var title: String?
     var artist: String?
     var album: String?
     var albumArt: String?
     var uri: String?
     var service: String?
-    var type: String?
     
     required init?(map: Map) {
-        
     }
     
     // Mappable
     func mapping(map: Map) {
+        type        <- (map["type"], ItemTypeTransform())
+        
         title       <- map["title"]
         artist      <- map["artist"]
         album       <- map["album"]
         albumArt    <- map["albumart"]
         uri         <- map["uri"]
         service     <- map["service"]
-        type        <- map["type"]
+    }
+}
+
+/// Transform for JSON mapping from string to `ItemType` and vice versa.
+class ItemTypeTransform: TransformType {
+    public typealias Object = ItemType
+    public typealias JSON = String
+    
+    public init() {}
+    
+    /// Transforms a string from JSON into `ItemType`. Unknown strings will become `ItemType.unknown`.
+    open func transformFromJSON(_ value: Any?) -> ItemType? {
+        if let typeString = value as? String {
+            return ItemType(rawValue: typeString) ?? .unknown
+        }
+        return .unknown
+    }
+    
+    open func transformToJSON(_ value: ItemType?) -> String? {
+        if let type = value {
+            return type.rawValue
+        }
+        return nil
     }
 }

--- a/Volumio/NetworkObject.swift
+++ b/Volumio/NetworkObject.swift
@@ -18,7 +18,6 @@ class NetworkObject: Mappable {
     var type: String?
     
     required init?(map: Map) {
-        
     }
     
     // Mappable

--- a/Volumio/PluginObject.swift
+++ b/Volumio/PluginObject.swift
@@ -17,7 +17,6 @@ class PluginObject: Mappable {
     var category: String?
     
     required init?(map: Map) {
-        
     }
     
     // Mappable

--- a/Volumio/QueueTableViewController.swift
+++ b/Volumio/QueueTableViewController.swift
@@ -123,14 +123,8 @@ class QueueTableViewController: UITableViewController, QueueActionsDelegate {
         let cell = tableView.dequeueReusableCell(withIdentifier: "track", for: indexPath) as! QueueTableViewCell
         let track = queue[indexPath.row]
         
-        cell.trackArtist.text = "" // TODO: quickfix for cell reuse
-
-        cell.trackTitle.text = track.name ?? ""
-        if let artist = track.artist,
-            let album = track.album {
-            // TODO: refactor string formatting to avoid code duplication
-            cell.trackArtist.text = "\(artist) - \(album)"            
-        }
+        cell.trackTitle.text = track.localizedTitle
+        cell.trackArtist.text = track.localizedArtistAndAlbum
         
         cell.trackPosition.text = "\(indexPath.row + 1)"
                 

--- a/Volumio/SearchResultObject.swift
+++ b/Volumio/SearchResultObject.swift
@@ -13,7 +13,6 @@ class SearchResultObject: Mappable {
     var title: String?
     
     required init?(map: Map) {
-        
     }
     
     // Mappable

--- a/Volumio/Service.swift
+++ b/Volumio/Service.swift
@@ -1,0 +1,16 @@
+//
+//  Service.swift
+//  Volumio
+//
+//  Created by Michael Baumgärtner on 24.01.17.
+//  Copyright © 2017 Federico Sintucci. All rights reserved.
+//
+
+import Foundation
+
+enum ServiceType: String {
+    case generic
+    case folder
+    case playlist
+    case music_service
+}

--- a/Volumio/SourceObject.swift
+++ b/Volumio/SourceObject.swift
@@ -15,7 +15,6 @@ class SourceObject: Mappable {
     var uri: String?
     
     required init?(map: Map) {
-        
     }
     
     // Mappable

--- a/Volumio/TrackObject.swift
+++ b/Volumio/TrackObject.swift
@@ -9,6 +9,8 @@
 import ObjectMapper
 
 class TrackObject: Mappable {
+    var type: ItemType = .track
+
     var title: String?
     var name: String?
     var artist: String?
@@ -26,7 +28,6 @@ class TrackObject: Mappable {
     var position: Int?
     
     required init?(map: Map) {
-        
     }
     
     // Mappable

--- a/Volumio/TrackObject.swift
+++ b/Volumio/TrackObject.swift
@@ -8,7 +8,7 @@
 
 import ObjectMapper
 
-class TrackObject: Mappable {
+class TrackObject: Mappable, Item {
     var type: ItemType = .track
 
     var title: String?
@@ -16,15 +16,17 @@ class TrackObject: Mappable {
     var artist: String?
     var album: String?
     var albumArt: String?
+    
+    var uri: String?
+    var service: String?
+
     var volume: Int?
     var seek: Int?
     var duration: Int?
-    var uri: String?
     var status: String?
     var repetition: Int?
     var shuffle: Int?
     var consume: Int?
-    var service: String?
     var position: Int?
     
     required init?(map: Map) {


### PR DESCRIPTION
This adds a model type for Volumio items. It can be a song, a playlist, a folder, and so forth. An enum defines different item types. The idea is to use this item type to collate duplicated code related to Volumio’s items. See localized string properties for a first step.